### PR TITLE
Daemon reload requires elevated privileges

### DIFF
--- a/roles/docker/tasks/configure.yml
+++ b/roles/docker/tasks/configure.yml
@@ -19,6 +19,7 @@
 
 - name: reload systemd
   command: systemctl daemon-reload
+  become: yes
   when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 20
 
 - name: Start the docker service


### PR DESCRIPTION
The daemon reload command needs to be run with root privileges. Added become directive.